### PR TITLE
Update FreeNAS dashboard

### DIFF
--- a/Freenas.json
+++ b/Freenas.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1536387620340,
+  "iteration": 1553063290438,
   "links": [],
   "panels": [
     {
@@ -533,6 +533,10 @@
                   "value"
                 ],
                 "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
               }
             ]
           ],
@@ -541,12 +545,6 @@
               "key": "host",
               "operator": "=~",
               "value": "/^$host$/"
-            },
-            {
-              "condition": "AND",
-              "key": "resource",
-              "operator": "=",
-              "value": "interface-bge0"
             }
           ]
         }
@@ -651,8 +649,8 @@
             {
               "condition": "AND",
               "key": "resource",
-              "operator": "=",
-              "value": "df-mnt-media"
+              "operator": "=~",
+              "value": "/^$df_resource$/"
             }
           ]
         }
@@ -698,21 +696,22 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
           "groupBy": [],
-          "measurement": "cpu-system",
+          "measurement": "cpu-interrupt",
           "orderByTime": "ASC",
           "policy": "default",
-          "refId": "E",
+          "refId": "B",
           "resultFormat": "time_series",
           "select": [
             [
@@ -783,10 +782,10 @@
         },
         {
           "groupBy": [],
-          "measurement": "cpu-interrupt",
+          "measurement": "cpu-system",
           "orderByTime": "ASC",
           "policy": "default",
-          "refId": "B",
+          "refId": "E",
           "resultFormat": "time_series",
           "select": [
             [
@@ -821,6 +820,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Usage",
       "tooltip": {
@@ -946,8 +946,8 @@
             {
               "condition": "AND",
               "key": "resource",
-              "operator": "=",
-              "value": "df-mnt-media"
+              "operator": "=~",
+              "value": "/^$df_resource$/"
             }
           ]
         }
@@ -992,6 +992,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1079,6 +1080,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "System load",
       "tooltip": {
@@ -1244,6 +1246,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1331,6 +1334,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory",
       "tooltip": {
@@ -1396,6 +1400,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1458,6 +1463,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Swap",
       "tooltip": {
@@ -1524,6 +1530,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1600,6 +1607,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Ops",
       "tooltip": {
@@ -1665,6 +1673,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1877,6 +1886,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk latency",
       "tooltip": {
@@ -1942,6 +1952,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -2060,6 +2071,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Busy",
       "tooltip": {
@@ -2125,6 +2137,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -2135,6 +2148,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "alias": "Temp: $tag_resource",
           "groupBy": [
             {
               "params": [
@@ -2147,7 +2161,7 @@
           "orderByTime": "ASC",
           "policy": "default",
           "query": "SELECT ((\"value\" -2731.5)/10) FROM \"temperature\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY \"resource\"",
-          "rawQuery": true,
+          "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -2160,7 +2174,7 @@
               },
               {
                 "params": [
-                  "-2731.5"
+                  " / 10 - 273.15"
                 ],
                 "type": "math"
               }
@@ -2172,14 +2186,142 @@
               "key": "host",
               "operator": "=~",
               "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "resource",
+              "operator": "=~",
+              "value": "/cputemp-*/"
             }
           ]
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Temp",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "celsius",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_FREENAS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 41,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Temp: $tag_resource",
+          "groupBy": [
+            {
+              "params": [
+                "resource"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "temperature",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT ((\"value\" -2731.5)/10) FROM \"temperature\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY \"resource\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "resource",
+              "operator": "=~",
+              "value": "/disktemp*/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "HDD Temp",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2227,7 +2369,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 45
+        "y": 51
       },
       "id": 21,
       "legend": {
@@ -2243,16 +2385,23 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "/TX:*/",
+          "transform": "negative-Y"
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
+          "alias": "RX: $tag_resource",
           "groupBy": [
             {
               "params": [
@@ -2285,6 +2434,7 @@
           ]
         },
         {
+          "alias": "TX: $tag_resource",
           "groupBy": [
             {
               "params": [
@@ -2319,6 +2469,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Interface traffic",
       "tooltip": {
@@ -2358,44 +2509,6 @@
       }
     },
     {
-      "alert": {
-        "conditions": [
-          {
-            "evaluator": {
-              "params": [
-                500000000000
-              ],
-              "type": "lt"
-            },
-            "operator": {
-              "type": "and"
-            },
-            "query": {
-              "params": [
-                "A",
-                "5m",
-                "now"
-              ]
-            },
-            "reducer": {
-              "params": [],
-              "type": "avg"
-            },
-            "type": "query"
-          }
-        ],
-        "executionErrorState": "alerting",
-        "frequency": "60s",
-        "handler": 1,
-        "message": "Low disk space on FreeNAS",
-        "name": "Disk usage alert",
-        "noDataState": "alerting",
-        "notifications": [
-          {
-            "id": 1
-          }
-        ]
-      },
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -2406,7 +2519,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 51
       },
       "id": 9,
       "legend": {
@@ -2422,47 +2535,18 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "paceLength": 10,
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "groupBy": [],
-          "measurement": "df_complex-free",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "host",
-              "operator": "=",
-              "value": "freenas_rhmlab_net"
-            },
-            {
-              "condition": "AND",
-              "key": "resource",
-              "operator": "=",
-              "value": "df-mnt-media"
-            }
-          ]
-        },
-        {
+          "alias": "Reserved",
           "groupBy": [],
           "measurement": "df_complex-reserved",
           "orderByTime": "ASC",
@@ -2488,12 +2572,13 @@
             {
               "condition": "AND",
               "key": "resource",
-              "operator": "=",
-              "value": "df-mnt-media"
+              "operator": "=~",
+              "value": "/^$df_resource$/"
             }
           ]
         },
         {
+          "alias": "Used",
           "groupBy": [],
           "measurement": "df_complex-used",
           "orderByTime": "ASC",
@@ -2519,22 +2604,47 @@
             {
               "condition": "AND",
               "key": "resource",
-              "operator": "=",
-              "value": "df-mnt-media"
+              "operator": "=~",
+              "value": "/^$df_resource$/"
+            }
+          ]
+        },
+        {
+          "alias": "Free",
+          "groupBy": [],
+          "measurement": "df_complex-free",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "resource",
+              "operator": "=~",
+              "value": "/^$df_resource$/"
             }
           ]
         }
       ],
-      "thresholds": [
-        {
-          "colorMode": "critical",
-          "fill": true,
-          "line": true,
-          "op": "lt",
-          "value": 500000000000
-        }
-      ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk usage",
       "tooltip": {
@@ -2575,7 +2685,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2634,5 +2744,5 @@
   "timezone": "",
   "title": "Freenas",
   "uid": "PcP5Wbmiz",
-  "version": 29
+  "version": 33
 }


### PR DESCRIPTION
I made some tweaks to the FreeNAS dashboard that makes it a little easier for others to use and tweaked some of the display to make it look a little nicer.

- Stack network values
- Only show CPU Temp in CPU Temp
- Add HDD Temp
- Allow user to select the mount point shown in chart
  - Remove the alert since the disk usage chart is now using a variable
- Fix some chart labeling